### PR TITLE
Add blacklist option

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -15,7 +15,7 @@ include { scatters } from './modules/local/scatters'
 workflow {
     make_bintable(params.config, params.genome)
     make_track_db(params.config, make_bintable.out.bins, params.meta) 
-    eigdecomp(params.config, make_bintable.out.bins, params.mcool)
+    eigdecomp(params.config, make_bintable.out.bins, params.blacklist, params.mcool)
     plot_spectrum(params.config, eigdecomp.out.eigvals)
     // make_multivec(params.config, eigdecomp.out.eigvals, eigdecomp.out.eigvecs)
     clustering(params.config, eigdecomp.out.eigvals, eigdecomp.out.eigvecs, make_bintable.out.bins)

--- a/modules/local/eigdecomp.nf
+++ b/modules/local/eigdecomp.nf
@@ -11,6 +11,7 @@ process eigdecomp {
     input:
         path config
         path bins
+        path blacklist
         path mcool
 
     output:
@@ -20,6 +21,6 @@ process eigdecomp {
     script:
 
     """ 
-    eigdecomp_main.py --config ${config} --bins ${bins} --cooler ${mcool}
+    eigdecomp_main.py --config ${config} --bins ${bins} --blacklist ${blacklist} --cooler ${mcool}
     """ 
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,6 +11,7 @@ params {
     // Input options
     config                      = null
     meta                        = null
+    blacklist                   = null
     mcool                       = null
     outdir                      = null
     skip_meta                   = true


### PR DESCRIPTION
The eigendecomp_main.py script was already able to accept the `blacklist` arg, but it wasn't accessible from the nextflow worflow level. I made it available at the top-level (where the mcool file is specified).