### PR TITLE
Remove strict bioframe versioning

### DIFF
--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - bioconda::ucsc-bedgraphtobigwig
   - bioconda::ucsc-bigwigtobedgraph
   - pip:
-      - bioframe==0.3.*
+      - bioframe
       - h5py
       - cooler
       - cooltools


### PR DESCRIPTION
Upcoming versions of bioframe have additional features such as new genome assembly data (hs1)