### PR TITLE
Fix: unauthenticated s3 and numpy::float64 fixes

### DIFF
--- a/bin/utils/common.py
+++ b/bin/utils/common.py
@@ -6,6 +6,8 @@ import numpy as np
 import pandas as pd
 import bbi
 import boto3
+from botocore import UNSIGNED
+from botocore.config import Config
 import os
 
 
@@ -13,7 +15,8 @@ def s3_to_local(s3_path, local_path):
     """
     Convert s3 paths to local file paths for pybbi to process.
     """
-    s3 = boto3.resource('s3')
+    # s3 = boto3.resource('s3')
+    s3 = boto3.client('s3', config=Config(signature_version=UNSIGNED))
 
     path_parts = s3_path.replace("s3://","").split("/")
     bucket=path_parts.pop(0)
@@ -23,7 +26,8 @@ def s3_to_local(s3_path, local_path):
         os.makedirs(local_path)
 
     filename = key.rsplit('/', 1)[-1]
-    s3.Object(bucket, key).download_file(local_path + filename)
+    # s3.Object(bucket, key).download_file(local_path + filename)
+    s3.download_file(bucket, key, local_path + filename)
     local_file = f"{local_path}{filename}"
 
     return local_file

--- a/bin/utils/eigdecomp.py
+++ b/bin/utils/eigdecomp.py
@@ -237,7 +237,7 @@ def eig_trans(
     # We actually extract n + 1 eigenvectors.
     # The first eigenvector, E0, will be uniform with eigenvalue 1.
     mask = np.sum(np.abs(A), axis=0) != 0
-    A_collapsed = A[mask, :][:, mask].astype(np.float, copy=True)
+    A_collapsed = A[mask, :][:, mask].astype(np.float64, copy=True)
     eigvals, eigvecs_collapsed = scipy.sparse.linalg.eigsh(
         A_collapsed,
         n_eigs + 1,
@@ -479,7 +479,7 @@ def eig_cis(
         if (A.shape[0] <= ignore_diags + n_eigs + 1) or (mask.sum() <= ignore_diags + n_eigs + 1):
             return _region, np.nan * np.ones(n_eigs+1), np.nan * np.ones((len(A), n_eigs+1))
 
-        A_collapsed = A[mask, :][:, mask].astype(np.float, copy=True)
+        A_collapsed = A[mask, :][:, mask].astype(np.float64, copy=True)
         eigvals, eigvecs_collapsed = scipy.sparse.linalg.eigsh(
             A_collapsed,
             n_eigs + 1,


### PR DESCRIPTION
This PR addresses two issues with the inspectro-nf pipeline:

1. Unauthenticated S3 reads result in errors. This adds support for unauthenticated S3 reads from public datasets.
2. numpy::float has been deprecated in recent versions of numpy. This updates them to numpy::float64

