### PR TITLE
avoid make_track_db crash by removing unused output

### DIFF
--- a/modules/local/make_track_db.nf
+++ b/modules/local/make_track_db.nf
@@ -15,7 +15,6 @@ process make_track_db {
 
     output:
         path "*.h5", emit: trackdb
-        path "local_track_files/*", emit: local_path
 
     script:
 


### PR DESCRIPTION
`local_track_files/*` path is not being created by `make_track_db` process and it makes the pipeline/nextflow crash at the very end of `make_track_db` step.

Besides, `make_track_db.out.local_path` is not used anywhere in `main.nf`

removing this output fixes the issue without affecting anything